### PR TITLE
Add nimbus beacon chain url at .env.example and deploy-heroku.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 PROVIDER_URL=
-BEACON_CHAIN_API_URL=https://lodestar-mainnet.chainsafe.io
+BEACON_CHAIN_API_URL=http://testing.mainnet.beacon-api.nimbus.team
 CHAIN_ID=1

--- a/src/provers/light-optimistic/deploy-heroku.sh
+++ b/src/provers/light-optimistic/deploy-heroku.sh
@@ -3,6 +3,6 @@ name=$1
 heroku create "$name" 
 git remote add "$name" "https://git.heroku.com/$name.git"
 
-heroku config:set --app "$name" BEACON_CHAIN_API_URL=https://lodestar-mainnet.chainsafe.io CHAIN_ID=1
+heroku config:set --app "$name" BEACON_CHAIN_API_URL=http://testing.mainnet.beacon-api.nimbus.team CHAIN_ID=1
 
 git push "$name" main


### PR DESCRIPTION
Change the outdated chainsafe url to the nimbus url.